### PR TITLE
Fix nested .gitignore matching and directory-pattern handling

### DIFF
--- a/tests/unit/test_gitignore_hierarchy_matching.py
+++ b/tests/unit/test_gitignore_hierarchy_matching.py
@@ -1,0 +1,46 @@
+"""Regression tests for gitignore hierarchy matching behavior."""
+
+from pathlib import Path
+
+from aci.core.gitignore_manager import GitignoreManager
+
+
+def test_nested_directory_pattern_ignores_files_under_that_directory(tmp_path):
+    """A nested .gitignore pattern like `out/` should ignore files inside that directory."""
+    (tmp_path / "apps" / "web").mkdir(parents=True)
+    (tmp_path / "apps" / "web" / ".gitignore").write_text("out/\n", encoding="utf-8")
+
+    manager = GitignoreManager(tmp_path)
+    manager.load_gitignore(tmp_path / "apps" / "web" / ".gitignore")
+
+    assert manager.matches(Path("apps") / "web" / "out", is_dir=True)
+    assert manager.matches(Path("apps") / "web" / "out" / "_next" / "static" / "chunks" / "framework.js", is_dir=False)
+    assert not manager.matches(Path("apps") / "web" / "src" / "app.js", is_dir=False)
+
+
+def test_nested_anchored_pattern_is_scoped_to_its_gitignore_directory(tmp_path):
+    """Anchored patterns in nested .gitignore files are anchored to that directory, not repository root."""
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "b").mkdir()
+    (tmp_path / "a" / ".gitignore").write_text("/build\n", encoding="utf-8")
+
+    manager = GitignoreManager(tmp_path)
+    manager.load_gitignore(tmp_path / "a" / ".gitignore")
+
+    assert manager.matches(Path("a") / "build", is_dir=False)
+    assert not manager.matches(Path("build"), is_dir=False)
+    assert not manager.matches(Path("a") / "b" / "build", is_dir=False)
+
+
+def test_nested_slash_pattern_is_scoped_to_its_gitignore_directory(tmp_path):
+    """Patterns containing slashes in nested .gitignore should stay scoped to that subtree."""
+    (tmp_path / "sub" / "nested" / "tmp").mkdir(parents=True)
+    (tmp_path / "other" / "tmp").mkdir(parents=True)
+    (tmp_path / "sub" / ".gitignore").write_text("tmp/*.js\n", encoding="utf-8")
+
+    manager = GitignoreManager(tmp_path)
+    manager.load_gitignore(tmp_path / "sub" / ".gitignore")
+
+    assert manager.matches(Path("sub") / "tmp" / "file.js", is_dir=False)
+    assert not manager.matches(Path("sub") / "nested" / "tmp" / "file.js", is_dir=False)
+    assert not manager.matches(Path("other") / "tmp" / "file.js", is_dir=False)


### PR DESCRIPTION
### Motivation
- Git-ignored files (e.g. build outputs like `out/`) were still being picked up by the scanner because nested `.gitignore` scoping and directory-pattern semantics did not match `git check-ignore` behavior.
- This caused unnecessary embedding API calls and token-limit errors when large generated files were indexed.

### Description
- Rewrote rule evaluation to produce a root-scoped effective pattern for each `GitignorePattern` via `_build_effective_pattern` and match using `pathspec` per-pattern instead of the previous custom anchored/unanchored logic.
- Added directory match candidates (`path` and `path/`) so directory-only patterns like `out/` correctly match directory entries and files beneath them during traversal.
- Added a per-pattern `PathSpec` cache (`_pattern_spec_cache`) and clear it when patterns/defaults are loaded to avoid repeated recompilation.
- Removed the older `_match_anchored`/`_match_unanchored` branching and added regression tests in `tests/unit/test_gitignore_hierarchy_matching.py` covering nested directory rules, anchored rules scoped to nested `.gitignore` dirs, and slash-containing rules (e.g. `tmp/*.js`).

### Testing
- Ran `pytest -q tests/unit/test_gitignore_hierarchy_matching.py` and the new regression tests passed.
- Ran a focused subset of `tests/unit/test_gitignore_error_handling.py` (excluding an environment-sensitive permission test) and the selected tests passed.
- Attempted to run property tests from `tests/property/test_gitignore_pattern_properties.py`, but collection failed due to the `hypothesis` dependency not being available in this environment.
- Note: one permission-related test that relies on `chmod` to make a file unreadable is environment-dependent and was observed to be flaky in this CI/runtime; other error-handling tests ran successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69950cde28048324a25245743575ef3d)