### PR TITLE
Fix Windows system directory detection for anchored paths

### DIFF
--- a/src/aci/core/path_utils.py
+++ b/src/aci/core/path_utils.py
@@ -93,8 +93,12 @@ def _is_windows_system_directory(resolved: Path, path_str: str) -> bool:
     windows_path = PureWindowsPath(path_str)
     win_parts = [part.lower() for part in windows_path.parts if part not in ("\\", "/")]
 
-    # Strip drive prefix (e.g., "c:") if present.
-    if win_parts and re.fullmatch(r"[a-z]:", win_parts[0]):
+    # Strip Windows anchor prefixes (e.g., "C:\\", "\\\\server\\share\\").
+    anchor = windows_path.anchor.lower()
+    if anchor and win_parts and win_parts[0] == anchor:
+        win_parts = win_parts[1:]
+    elif win_parts and re.fullmatch(r"[a-z]:", win_parts[0]):
+        # Defensive fallback for drive-only prefixes represented as "c:".
         win_parts = win_parts[1:]
 
     if win_parts and win_parts[0] in WINDOWS_SYSTEM_DIRS:


### PR DESCRIPTION
### Motivation
- Property tests were failing on non-Windows CI because `_is_windows_system_directory` produced false negatives for Windows paths that include an anchor (for example `C:\Program Files (x86)`), due to how `PureWindowsPath.parts` represents anchored paths on POSIX hosts.

### Description
- Update `_is_windows_system_directory` in `src/aci/core/path_utils.py` to inspect `PureWindowsPath.anchor` and strip Windows anchor prefixes (e.g. `C:\`, `\\server\share\`) before examining leading path components against `WINDOWS_SYSTEM_DIRS`.
- Preserve the defensive fallback that strips `c:`-style drive prefixes when present.
- Leave the existing resolved-`Path` fallback logic intact so native Windows behavior is unchanged.

### Testing
- Ran `pytest tests/unit/test_cli.py::TestCLIHelp::test_index_help tests/unit/test_cli.py::TestCLIHelp::test_search_help` and both tests passed locally.
- Attempted to run the property tests that originally failed, but test collection aborted with `ModuleNotFoundError: No module named 'hypothesis'` in this environment, so the property-suite validation could not be completed here.
- Prior to the fix the full test run reported `4 failed, 665 passed`; the change addresses the Windows-path detection failure that caused the property test failures in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6999b0a45bd48324b9d5433e78fb747a)