### PR TITLE
ci(test): remove duplicate push trigger on all branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: [ '**' ]
+    branches: [ 'master' ]
     tags-ignore: [ '**' ]
   pull_request:
     branches: [ '**' ]


### PR DESCRIPTION
Why: push on '**' + pull_request on '**' caused two identical CI runs
     every time a commit was pushed to a PR branch, wasting runner time.

What: narrow push trigger to master only (post-merge validation);
     pull_request continues to cover all PR branches for pre-merge checks.

Test: no logic change, only trigger scope adjusted